### PR TITLE
Change lib crc16 to libscrc

### DIFF
--- a/promptpay/qrcode.py
+++ b/promptpay/qrcode.py
@@ -1,5 +1,5 @@
 import re
-import crc16
+import libscrc
 import qrcode
 from PIL import Image
 
@@ -79,7 +79,7 @@ def checksum(target: str = "") -> str:
     :return:
     """
     byte_str = target.encode("ascii")  # convert to bytes
-    hex_str = hex(crc16.crc16xmodem(byte_str, 0xFFFF))
+    hex_str = hex(libscrc.xmodem(byte_str, 0xFFFF))
     code = hex_str.replace("0x", "").upper()
     result = ("0000" + code)[-4:]  # only last 4 digits
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-crc16==0.1.1
+libscrc==1.7.1
 Pillow==7.2.0
 qrcode==6.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import pathlib
 from setuptools import setup, find_packages
 
-requirements = ["qrcode", "crc16", "Pillow"]
+requirements = ["qrcode", "libscrc", "Pillow"]
 
 # The directory containing this file
 HERE = pathlib.Path(__file__).parent


### PR DESCRIPTION
crc16 is outdated, it shows 'SystemError: PY_SSIZE_T_CLEAN macro must be
defined for '#' formats' on python 3.10.4 (Kubuntu 22.04)